### PR TITLE
Surface detailed error message from Marathon

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,11 @@ type Marathon struct {
 	Url string
 }
 
+type ErrorDetails []struct {
+	Path   string   `json:"path"`
+	Errors []string `json:"errors"`
+}
+
 var httpClient = gorequest.New()
 
 func handle(response gorequest.Response, body string, errs []error) (string, error) {
@@ -20,7 +25,11 @@ func handle(response gorequest.Response, body string, errs []error) (string, err
 			if err != nil {
 				errs = append(errs, err)
 			} else {
-				errs = append(errs, errors.New(errorResponse["message"].(string)))
+				if response.StatusCode == 422 {
+					errs = append(errs, errors.New(errorResponse["details"].(ErrorDetails)[0].Errors[0]))
+				} else {
+					errs = append(errs, errors.New(errorResponse["message"].(string)))
+				}
 			}
 		} else if response.StatusCode != 200 && response.StatusCode != 201 {
 			errs = append(errs, errors.New(response.Status))

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"errors"
+
 	"github.com/parnurzeal/gorequest"
 )
 
@@ -10,9 +11,12 @@ type Marathon struct {
 	Url string
 }
 
-type ErrorDetails []struct {
-	Path   string   `json:"path"`
-	Errors []string `json:"errors"`
+type ErrorResponse struct {
+	Details []struct {
+		Errors []string `json:"errors"`
+		Path   string   `json:"path"`
+	} `json:"details"`
+	Message string `json:"message"`
 }
 
 var httpClient = gorequest.New()
@@ -20,15 +24,15 @@ var httpClient = gorequest.New()
 func handle(response gorequest.Response, body string, errs []error) (string, error) {
 	if response != nil {
 		if (response.StatusCode != 200 && response.StatusCode != 201) && body != "" {
-			var errorResponse map[string]interface{}
+			var errorResponse ErrorResponse
 			err := json.Unmarshal([]byte(body), &errorResponse)
 			if err != nil {
 				errs = append(errs, err)
 			} else {
 				if response.StatusCode == 422 {
-					errs = append(errs, errors.New(errorResponse["details"].(ErrorDetails)[0].Errors[0]))
+					errs = append(errs, errors.New(errorResponse.Details[0].Errors[0]))
 				} else {
-					errs = append(errs, errors.New(errorResponse["message"].(string)))
+					errs = append(errs, errors.New(errorResponse.Message))
 				}
 			}
 		} else if response.StatusCode != 200 && response.StatusCode != 201 {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -54,7 +54,7 @@ func TestHandleOn422UnprocessableEntity(t *testing.T) {
 	expectedBody := "{\"message\": \"Object is not valid\", \"details\": [{\"path\": \"/healthChecks(0)\",\"errors\": [\"Health check port indices must address an element of the ports array or container port mappings.\"]}]}"
 	assert.Equal(t, body, expectedBody)
 
-	expectedError := errors.New("Error(s): UnprocessableEntity Object is not valid")
+	expectedError := errors.New("Error(s): UnprocessableEntity Health check port indices must address an element of the ports array or container port mappings.")
 	assert.Equal(t, err, expectedError)
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,6 +48,16 @@ func TestHandleOnNon200Or201WhenBodyIsEmpty(t *testing.T) {
 	assert.Equal(t, err, expectedError)
 }
 
+func TestHandleOn422UnprocessableEntity(t *testing.T) {
+	body, err := handle(createMockResponse(422), createErrorResponseNew("Object is not valid"), []error{errors.New("UnprocessableEntity")})
+
+	expectedBody := "{\"message\": \"Object is not valid\", \"details\": [{\"path\": \"/healthChecks(0)\",\"errors\": [\"Health check port indices must address an element of the ports array or container port mappings.\"]}]}"
+	assert.Equal(t, body, expectedBody)
+
+	expectedError := errors.New("Error(s): UnprocessableEntity Object is not valid")
+	assert.Equal(t, err, expectedError)
+}
+
 func TestHandleNilResponse(t *testing.T) {
 	_, err := handle(nil, createErrorResponse("Invalid Request"), []error{errors.New("InvalidRequest")})
 	expectedError := errors.New("InvalidRequest")
@@ -79,4 +89,9 @@ func createErrorResponse(message string) string {
 		Message: message,
 	}
 	return util.ToJson(err)
+}
+
+func createErrorResponseNew(message string) string {
+	_ = message
+	return "{\"message\": \"Object is not valid\", \"details\": [{\"path\": \"/healthChecks(0)\",\"errors\": [\"Health check port indices must address an element of the ports array or container port mappings.\"]}]}"
 }


### PR DESCRIPTION
Marathon returns a detailed error message for specific status codes; this PR helps surface them when available.

**Use-case**
When the config JSON is valid but has problems (like invalid port index in health check, for example), Marathon returns a `422` error response. The response body looks like this —

```
{
	"message": "Object is not valid",
	"details": [{
		"path": "/healthChecks(0)",
		"errors": ["Health check port indices must address an element of the ports array or container port mappings."]
	}]
}
```

🙏🏻 to @extrasalt for helping finish up this PR!